### PR TITLE
Show hello endpoint in frontend

### DIFF
--- a/front-api-rest/src/views/Home.vue
+++ b/front-api-rest/src/views/Home.vue
@@ -1,11 +1,28 @@
 <template>
   <div>
-    <h1>Vue funcionando! 🎉</h1>
+    <h1>{{ message }}</h1>
   </div>
 </template>
 
 <script lang="ts">
-export default {
-  name: 'Home'
-}
+import { defineComponent } from 'vue'
+import api from '../services/api.js'
+
+export default defineComponent({
+  name: 'Home',
+  data() {
+    return {
+      message: 'Carregando...'
+    }
+  },
+  async created() {
+    try {
+      const response = await api.get('/')
+      this.message = response.data
+    } catch (error) {
+      console.error('Erro ao buscar API', error)
+      this.message = 'Erro ao acessar API'
+    }
+  }
+})
 </script>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "axios": "^1.9.0",
     "dotenv": "^16.5.0",
     "express": "^4.21.2",
-    "pg": "^8.16.0"
+    "pg": "^8.16.0",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "nodemon": "^3.1.9"

--- a/src/app.js
+++ b/src/app.js
@@ -1,10 +1,12 @@
 import express from "express";
 import selecaoRoutes from "./routes/selecao.routes.js";
 import dotenv from "dotenv";
+import cors from "cors";
 
 dotenv.config();
 
 const app = express();
+app.use(cors());
 app.use(express.json());
 
 app.get("/", (req, res) => res.send("Hello World!"));


### PR DESCRIPTION
## Summary
- enable CORS in the API to allow browser requests
- display the API '/' response in the Home page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855ad5a84508329afe42a808ec89b31